### PR TITLE
fix: switched to slim python images

### DIFF
--- a/virtual-machine/celery/Dockerfile
+++ b/virtual-machine/celery/Dockerfile
@@ -1,6 +1,13 @@
-# Use Python 3.11.8 base image
-FROM python:3.11.8
+FROM python:3.11.8-slim
 
+# Install required system dependencies
+RUN apt-get update && apt-get install -y \
+    gcc \
+    libffi-dev \
+    libpq-dev \
+    build-essential \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
 # Copy application files (including requirements.txt) into the container
 COPY app /app
 

--- a/virtual-machine/fast-api/Dockerfile
+++ b/virtual-machine/fast-api/Dockerfile
@@ -1,5 +1,12 @@
 # Use Python 3.11.8 base image
-FROM python:3.11.8
+FROM python:3.11.8-slim
+
+# Install system dependencies and bash (if needed)
+RUN apt-get update && apt-get install -y \
+    gcc \
+    libpq-dev \
+    bash && \
+    rm -rf /var/lib/apt/lists/*
 
 # Copy application files (including requirements.txt) into the container
 COPY app /app


### PR DESCRIPTION
Switched to Python Slim images for Celery and FastAPI Dockerfiles.